### PR TITLE
Update TransformationInstruction.cs

### DIFF
--- a/BREPipelineFramework/BREPipelineFramework.SampleInstructions/Instructions/TransformationInstruction.cs
+++ b/BREPipelineFramework/BREPipelineFramework.SampleInstructions/Instructions/TransformationInstruction.cs
@@ -8,6 +8,7 @@ using BREPipelineFramework.Helpers;
 using Microsoft.BizTalk.Streaming;
 using BREPipelineFramework.Helpers.Tracing;
 using Microsoft.BizTalk.Component;
+using Microsoft.XLANGs.BaseTypes;
 
 namespace BREPipelineFramework.SampleInstructions.Instructions
 {
@@ -89,7 +90,7 @@ namespace BREPipelineFramework.SampleInstructions.Instructions
             {
                 XPathDocument input = new XPathDocument(inmsg.BodyPart.GetOriginalDataStream());
                 pc.ResourceTracker.AddResource(input);
-                dynamic transform = transformMetaData.Transform;
+                ITransform transform = transformMetaData.Transform;
                 Stream output = new VirtualStream();
 
                 TraceManager.PipelineComponent.TraceInfo("{0} - Applying transformation {1} to the message", callToken, mapName);


### PR DESCRIPTION
I changed the **transform** object, which conducts the dynamic transformation, from **dynamic** type to **ITransform**.

This fixed the runtime error in BizTalk Server 2020 due to a breaking change, where it is resolved to the new ITransform2 type when using the dynamic keyword. 

This should work with BizTalk 2013+, but it will not work with BizTalk 2010.